### PR TITLE
Potential fix for code scanning alert no. 77: Server-side request forgery

### DIFF
--- a/routes/profileImageUrlUpload.ts
+++ b/routes/profileImageUrlUpload.ts
@@ -43,7 +43,13 @@ export function profileImageUrlUpload () {
             return
           }
 
-          const response = await fetch(url)
+          // Reconstruct the URL from trusted components only
+          if (parsedUrl.username || parsedUrl.password || parsedUrl.hash) {
+            next(new Error('Userinfo or fragments not allowed in image URL'))
+            return
+          }
+          const safeUrl = `${parsedUrl.protocol}//${parsedUrl.hostname}${parsedUrl.pathname}${parsedUrl.search}`
+          const response = await fetch(safeUrl)
           if (!response.ok || !response.body) {
             throw new Error('url returned a non-OK status code or an empty body')
           }


### PR DESCRIPTION
Potential fix for [https://github.com/Fabio-Takashi/juice-shop-ada-1497/security/code-scanning/77](https://github.com/Fabio-Takashi/juice-shop-ada-1497/security/code-scanning/77)

To properly fix the SSRF vulnerability, we must ensure that the actual outgoing request is made strictly to an allow-listed hostname and protocol. That means not passing the originally supplied `url` string directly to `fetch()`, but rather reconstructing the URL from the already validated (parsed) URL object. Specifically:
- After parsing and validating the protocol and hostname, reconstruct the full request URL using `parsedUrl.protocol`, `parsedUrl.hostname`, and `parsedUrl.pathname`/`parsedUrl.search`.
- Disallow portions of the URL that could be used for obfuscation (e.g., a userinfo component), ensuring the output does not contain user-controlled credentials or fragment.
- Within `profileImageUrlUpload`, on lines 46 and surrounding, modify the code to build the outgoing request URL from trusted components, then pass this to `fetch()`, *not* the untrusted input.
- No change to existing endpoint logic.
- If needed, import/use appropriate Node.js or standard JavaScript library methods for safe URL reconstruction.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
